### PR TITLE
Add list command

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -293,3 +293,25 @@ func TestGetDashboardInfo(t *testing.T) {
 		t.Errorf("url should be empty, got %s", url)
 	}
 }
+
+// TestStripBadField function that test stripBadField()
+func TestStripBadField(t *testing.T) {
+	input := `{"a":"b","c":"d","e":"f"}`
+	expectedOutput := `{"a":"b","e":"f"}`
+
+	output, err := stripBadField([]byte(input), "c")
+
+	if err != nil {
+		t.Errorf("err should be nil, got %v", err)
+	}
+
+	if string(output) != expectedOutput {
+		t.Errorf("output should be `%v`, got `%v`", expectedOutput, string(output))
+	}
+
+	_, err = stripBadField([]byte("foo"), "c")
+
+	if err == nil {
+		t.Errorf("err should not be nil")
+	}
+}

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -1,4 +1,4 @@
-package utils
+package commands
 
 import (
 	"io/ioutil"

--- a/commands/list.go
+++ b/commands/list.go
@@ -1,0 +1,115 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+// Dashboard structure definition, mapped from Datadog type
+type Dashboard struct {
+	createdAt   string `json:"created_at"`
+	isReadOnly  bool   `json:"is_read_only"`
+	description string `json:  "description"`
+	ID          string `json: "id"`
+	Title       string `json:  "title"`
+	URL         string `json: "url"`
+	layoutType  string `json:  "layout_type"`
+	modifiedAt  string `json: "modified_at"`
+	Author      string `json: "author_handle"`
+}
+
+// DashboardList structure definition
+type DashboardList struct {
+	dashboards []Dashboard `json:"dashboards"`
+}
+
+func init() {
+	log.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+	})
+}
+
+// ListCmd pull to List existing dashboard defined in Datadog.
+var ListCmd = cli.Command{
+	Name:   "list",
+	Usage:  "List dashboard existing in Datadog.",
+	Action: list,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "format",
+			Usage: "Format of the list of dashboard.",
+			Value: "json",
+		},
+		cli.StringFlag{
+			Name:  "o, output",
+			Usage: "output file to print dashboard list.",
+			Value: "stdout",
+		},
+	},
+}
+
+func list(c *cli.Context) (err error) {
+
+	var (
+	// dashboardList DashboardList
+	)
+
+	_, err = getDashboardList(c.GlobalString("dh"), c.GlobalString("api-key"), c.GlobalString("app-key"))
+	return nil
+}
+
+func getDashboardList(ddEndpoint string, apiKey string, appKey string) (DashboardList, error) {
+
+	var (
+		dashboardList DashboardList
+		body          []byte
+		query         string
+		statusCode    int
+	)
+
+	log.Info("Getting list of dashboards")
+
+	query = ddEndpoint + "/api/v1/dashboard?api_key=" + apiKey + "&application_key=" + appKey
+	fmt.Printf("query: %v \n", query)
+	resp, err := http.Get(query)
+
+	if err != nil {
+		log.Error("Error connectiong to ", query)
+		return dashboardList, err
+	}
+
+	defer resp.Body.Close()
+
+	statusCode = resp.StatusCode
+
+	if statusCode != 200 {
+		log.Error("Returned code is not 200, it's ", statusCode)
+		return dashboardList, errors.New("Returned code is not 200")
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		log.Error("Error when reading body response. ", err)
+		return dashboardList, errors.New("Error when reading body response")
+	}
+
+	fmt.Printf("\nbody:\n%v", string(body))
+
+	err = json.Unmarshal(body, &dashboardList)
+
+	if err != nil {
+		log.Error("Error when unmarshalling Json to Struct.", err)
+		return dashboardList, errors.New("Error when unmarshalling Json to Struct")
+	}
+
+	fmt.Printf("\nlist: %v", dashboardList)
+
+	return dashboardList, nil
+}

--- a/commands/list.go
+++ b/commands/list.go
@@ -43,7 +43,7 @@ var ListCmd = cli.Command{
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "format",
-			Usage: "Format of the list of dashboard.",
+			Usage: "Format of the list of dashboard. Supported values are `text` or json.",
 			Value: "text",
 		},
 		cli.StringFlag{
@@ -64,7 +64,7 @@ func list(c *cli.Context) (err error) {
 		dashboardList DashboardList
 	)
 
-	// Getting a list off all dashboard
+	// Getting a list off all dashboards
 	dashboardList, err = getDashboardList(c.GlobalString("dh"), c.GlobalString("api-key"), c.GlobalString("app-key"))
 
 	if err != nil {
@@ -89,7 +89,7 @@ func list(c *cli.Context) (err error) {
 	return nil
 }
 
-// getDashboardList function that qeury Datadog to get list of dashboard
+// getDashboardList function that query Datadog to get list of dashboard
 // then map the result into DashboardList structure.
 func getDashboardList(ddEndpoint string, apiKey string, appKey string) (DashboardList, error) {
 
@@ -152,6 +152,9 @@ func output(dashboardList DashboardList, format string, verbose bool) error {
 				fmt.Printf("%v | %v\n", dashboard.Title, dashboard.ID)
 			}
 		}
+	case "json":
+		b, _ := json.Marshal(dashboardList)
+		fmt.Printf("%v\n", string(b))
 
 	default:
 		for _, dashboard := range dashboardList.Dashboards {

--- a/commands/list.go
+++ b/commands/list.go
@@ -26,7 +26,7 @@ type Dashboard struct {
 
 // DashboardList structure definition
 type DashboardList struct {
-	dashboards []Dashboard `json:"dashboards"`
+	Dashboards []Dashboard `json:"dashboards"`
 }
 
 func init() {
@@ -99,8 +99,6 @@ func getDashboardList(ddEndpoint string, apiKey string, appKey string) (Dashboar
 		log.Error("Error when reading body response. ", err)
 		return dashboardList, errors.New("Error when reading body response")
 	}
-
-	fmt.Printf("\nbody:\n%v", string(body))
 
 	err = json.Unmarshal(body, &dashboardList)
 

--- a/commands/list.go
+++ b/commands/list.go
@@ -64,14 +64,22 @@ func list(c *cli.Context) (err error) {
 		dashboardList DashboardList
 	)
 
-	dashboardList, err = getDashboardList(c.GlobalString("dh"), c.GlobalString("api-key"), c.GlobalString("app-key"))
+	id := c.String("id")
 
-	if err != nil {
-		log.Error("Error when retrieving dashboard list.")
-		return err
+	if len(id) > 0 {
+		// Getting details for 1 dashboard
+		fmt.Printf("id: %v \n", c.String("id"))
+	} else {
+		// Getting a list off all dashboard
+		dashboardList, err = getDashboardList(c.GlobalString("dh"), c.GlobalString("api-key"), c.GlobalString("app-key"))
+
+		if err != nil {
+			log.Error("Error when retrieving dashboard list.")
+			return err
+		}
+
+		output(dashboardList, c.String("format"))
 	}
-
-	output(dashboardList, c.String("format"))
 
 	return nil
 }
@@ -126,8 +134,15 @@ func getDashboardList(ddEndpoint string, apiKey string, appKey string) (Dashboar
 
 func output(dashboardList DashboardList, format string) error {
 
-	for _, dashboard := range dashboardList.Dashboards {
-		fmt.Printf("%v | %v\n", dashboard.Title, dashboard.ID)
+	switch format {
+	case "text":
+		for _, dashboard := range dashboardList.Dashboards {
+			fmt.Printf("%v | %v\n", dashboard.Title, dashboard.ID)
+		}
+	default:
+		for _, dashboard := range dashboardList.Dashboards {
+			fmt.Printf("%v | %v\n", dashboard.Title, dashboard.ID)
+		}
 	}
 
 	return nil

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -1,4 +1,4 @@
-package utils
+package commands
 
 import (
 	"bytes"

--- a/commands/push.go
+++ b/commands/push.go
@@ -1,4 +1,4 @@
-package utils
+package commands
 
 import (
 	"bytes"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"dogsitter/utils"
+	"dogsitter/commands"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -43,8 +43,9 @@ func main() {
 	}
 
 	app.Commands = []cli.Command{
-		utils.PullCmd,
-		utils.PushCmd,
+		commands.PullCmd,
+		commands.PushCmd,
+		commands.ListCmd,
 	}
 
 	err := app.Run(os.Args)


### PR DESCRIPTION
This PR does the following:
- Add a command to list all dashboards, and display for a specific dashboard.
- Remove a field from the payload returned by Datadog that prevent the dashboard to be imported.
- Renamed package utils to commands.